### PR TITLE
Fix for Use of exit() or quit()

### DIFF
--- a/splitlog/__main__.py
+++ b/splitlog/__main__.py
@@ -76,7 +76,7 @@ def _parse_args(args: List[str]) -> _Arguments:
 
 def _error_exit(error: Exception) -> None:
     print(error, file=sys.stderr)
-    exit(1)
+    sys.exit(1)
 
 
 def _open_input(file: Optional[Path]) -> BinaryIO:
@@ -97,7 +97,7 @@ def _version_exit():
     else:
         print(f"{_NAME} {version}")
 
-    exit(0)
+    sys.exit(0)
 
 
 def main(cli_args: Optional[List[str]] = None) -> None:


### PR DESCRIPTION
Use `sys.exit(...)` instead of `exit(...)` in script/runtime code.

Best fix here (without changing functionality):
- In `splitlog/__main__.py`, replace:
  - line 79: `exit(1)` → `sys.exit(1)`
  - line 100: `exit(0)` → `sys.exit(0)`
- No new imports are needed because `sys` is already imported on line 2.
- This preserves behavior (same exit codes) while removing dependency on `site.Quitter`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._